### PR TITLE
feat: /withdraw endpoint & client wrapper

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -150,6 +150,15 @@ export default class ClientManager {
     };
   }
 
+  public async withdraw(params: PublicParams.Withdraw) {
+    const client = this.getClient();
+    if (params.assetId === AddressZero) {
+      delete params.assetId;
+    }
+    const response = await client.withdraw(params);
+    return response;
+  }
+
   public async subscribe(params: EventSubscriptionParams): Promise<{ id: string }> {
     const client = this.getClient();
     const subscription = await this._subscriber.subscribe(client, params);

--- a/src/index.ts
+++ b/src/index.ts
@@ -159,6 +159,16 @@ app.post("/deposit", async (req, res) => {
   }
 });
 
+app.post("/withdraw", async (req, res) => {
+  try {
+    await requireParam(req.body, "amount");
+    res.status(200).send(await clientManager.withdraw(req.body));
+  } catch (error) {
+    app.log.error(error);
+    res.status(500).send({ message: error.message });
+  }
+});
+
 app.post("/subscribe", async (req, res) => {
   try {
     await requireParam(req.body, "event");


### PR DESCRIPTION
This adds a `/withdraw` endpoint and a wrapper for the built-in Connext `withdraw` client method.