### PR TITLE
feat: /hashlock-cancel endpoint

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -49,7 +49,7 @@ import {
 } from "./helpers";
 import Subscriber from "./subscriber";
 
-const { AddressZero } = constants;
+const { AddressZero, HashZero } = constants;
 
 export default class Client {
   public static async init(logger: any) {
@@ -175,8 +175,9 @@ export default class Client {
     const client = this.getClient();
     const response = await client.resolveCondition({
       conditionType: ConditionalTransferTypes.HashLockTransfer,
-      preImage: params.preImage,
+      preImage: params.preImage || HashZero,
       assetId: params.assetId,
+      paymentId: params.paymentId,
     } as PublicParams.ResolveHashLockTransfer);
     return response;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -347,7 +347,6 @@ const routes = () => {
     { ...Routes.post.hashLockResolve.opts, preHandler: app.auth([app.verifyApiKey]) },
     async (req, res) => {
       try {
-        await requireParam(req.body, "preImage");
         await requireParam(req.body, "assetId");
         res.status(200).send<PostHashLockResolveResponse>(await client.hashLockResolve(req.body));
       } catch (error) {

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -415,7 +415,7 @@ export const Routes = {
           body: {
             type: "object",
             properties: {
-              preImage: { type: "string" },
+              preImage: { type: "string", nullable: true },
               assetId: { type: "string" },
               paymentId: { type: "string", nullable: true },
             },


### PR DESCRIPTION
This adds a new endpoint for cooperatively canceling incoming hash lock transfers. `/hashlock-cancel` requires a `paymentId` parameter and passes in a fixed empty string to the `resolveCondition` method for `preImage`.

Following the approach described here: https://github.com/ExchangeUnion/xud/issues/1730#issuecomment-658820930

Related issue #39 - the exiting `/hashlock-resolve` endpoint doesn't use the `paymentId` parameter so I don't see a way to do cooperative cancel without a change like in this PR.