### PR TITLE
feat: /request-collateral endpoint

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -46,6 +46,7 @@ import {
   PostLinkedResolveResponse,
   GetTransferHistory,
   fetchAll,
+  PostRequestCollateralRequestParams,
 } from "./helpers";
 import Subscriber from "./subscriber";
 
@@ -264,6 +265,11 @@ export default class Client {
       freeBalanceOffChain: response.freeBalance[client.signerAddress].toString(),
       freeBalanceOnChain: await getFreeBalanceOnChain(client, assetId),
     };
+  }
+
+  public async requestCollateral(params: PostRequestCollateralRequestParams): Promise<void> {
+    const client = this.getClient();
+    await client.requestCollateral(params.assetId);
   }
 
   public async swap(params: PostSwapRequestParams): Promise<PostSwapResponse> {

--- a/src/helpers/types.ts
+++ b/src/helpers/types.ts
@@ -68,6 +68,8 @@ export type GetTransferHistory = NodeResponses.GetTransferHistory;
 
 export type PostDepositRequestParams = PublicParams.Deposit;
 
+export type PostRequestCollateralRequestParams = { assetId: string };
+
 export type PostHashLockTransferRequestParams = PublicParams.HashLockTransfer;
 export interface PostHashLockTransferResponse
   extends PublicResults.ConditionalTransfer,

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,7 @@ import {
   PostLinkedResolveResponse,
   PostSwapRequestParams,
   PostSwapResponse,
+  PostRequestCollateralRequestParams,
 } from "./helpers";
 
 const app = fastify({
@@ -387,6 +388,24 @@ const routes = () => {
         await requireParam(req.body, "amount");
         await requireParam(req.body, "assetId");
         res.status(200).send<GetBalanceResponse>(await client.deposit(req.body));
+      } catch (error) {
+        app.log.error(error);
+        res.status(500).send<GenericErrorResponse>({ message: error.message });
+      }
+    },
+  );
+
+  interface PostRequestCollateralRequest extends RequestGenericInterface {
+    Body: PostRequestCollateralRequestParams;
+  }
+
+  app.post<PostRequestCollateralRequest>(
+    Routes.post.requestCollateral.url,
+    { ...Routes.post.requestCollateral.opts, preHandler: app.auth([app.verifyApiKey]) },
+    async (req, res) => {
+      try {
+        await requireParam(req.body, "assetId");
+        res.status(200).send<void>(await client.requestCollateral(req.body));
       } catch (error) {
         app.log.error(error);
         res.status(500).send<GenericErrorResponse>({ message: error.message });

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -517,6 +517,24 @@ export const Routes = {
         },
       },
     },
+    requestCollateral: {
+      url: "/request-collateral",
+      description: "Request collateral for an asset",
+      opts: {
+        schema: {
+          body: {
+            type: "object",
+            properties: {
+              assetId: { type: "string" },
+            },
+          },
+          response: {
+            200: {},
+            500: GenericErrorResponseSchema,
+          },
+        },
+      },
+    },
     swap: {
       url: "/swap",
       description: "Swap asset on channel",


### PR DESCRIPTION
This adds a new endpoint that calls `client.requestCollateral` to request collateral for a specified asset.

This is in place of the now closed #61 pR. 