### PR TITLE
Update Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,2 @@
 .git
 node_modules
-src

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,14 @@
-FROM node:12
-
+FROM node:lts-alpine3.12 AS builder
+RUN apk add --no-cache git bash python3 make g++ python2
 WORKDIR /app
-
-COPY package*.json ./
-
-RUN npm install
-
 COPY . .
+RUN  npm install && npm run build && rm -rf node_modules
 
-RUN /app/node_modules/.bin/tsc -p tsconfig.json
+
+FROM node:lts-alpine3.12
+WORKDIR /app
+COPY --from=builder /app /app
+RUN npm install --production
 
 EXPOSE  5040
-
-CMD ["node", "/app/build/src"]
+CMD ["npm", "run", "prod"]


### PR DESCRIPTION
This removes the need of first locally building with a matching versino of node when building the image

* Use alpine instead of debian for base
* Copy build artifacts from builder image instead of host
* Discard unneeded build dependencies from final image